### PR TITLE
Some minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ rm = rm -f
 
 all: send-sds receive-sds
 
-send-sds: $(sources) $(headers)
+send-sds: send-sds.c $(sources) $(headers)
 	$(compiler) $(compiler_flags) -o $@ send-sds.c $(sources) $(libraries)
 
-receive-sds: $(sources) $(headers)
+receive-sds: receive-sds.c $(sources) $(headers)
 	$(compiler) $(compiler_flags) -o $@ receive-sds.c $(sources) $(libraries)
 
 .PHONY: clean

--- a/err.h
+++ b/err.h
@@ -1,6 +1,8 @@
 #ifndef __ERR_H__
 #define __ERR_H__
 
+#include <stddef.h>
+
 /* make err_t opaque */
 struct err;
 typedef struct err * err_t;

--- a/receive-sds.c
+++ b/receive-sds.c
@@ -56,7 +56,7 @@ int main(int argc, char **argv) {
     channel_string = NULL;
     channel_num = 0;
     fd = 0;
-    err = NULL;
+    err = err_create(256);
     midi = NULL;
 
     if (argc != 4) {


### PR DESCRIPTION
The `receive-sds.c` file never allocates an `err` object, so if any errors did happen they would cause the program to dereference a null pointer in the calls to `err_set`.

`err.h` uses `size_t`  without including its definition.

The makefile doesn't rebuild `send-sds` and `receive-sds` if their source files change.